### PR TITLE
doc: remove code duplication in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var compressedSize = LZ4.encodeBlock(input, output)
 // remove unnecessary bytes
 output = output.slice(0, compressedSize)
 
-console.log( "compressed data", output.slice(0, compressedSize) )
+console.log( "compressed data", output )
 
 // block decompression (no archive format)
 var uncompressed = new Buffer(input.length)


### PR DESCRIPTION
This removes code duplication in the code example.
Instead of calling the function twice, we use the value generated by the first function call.